### PR TITLE
Fix mod_ubpf_api includes and add plugin archives generator

### DIFF
--- a/archive_gen.sh
+++ b/archive_gen.sh
@@ -1,0 +1,12 @@
+#! /bin/bash -e
+
+info () {
+    echo -e "[INFO] ${*}"
+}
+
+PLUGINS=($(ls -d */ | sed -E "s/\///g;s/xbgp_compliant_api//g;s/docs//g;s/prove_stuffs//g"))
+for PLUGIN in ${PLUGINS[@]}
+do
+    tar cjf "${PLUGIN}.tar.bz2" -h "${PLUGIN}" xbgp_compliant_api/*.h prove_stuffs/{*.h,*.c} *.h
+    info "${PLUGIN} archived."
+done

--- a/prove_stuffs/mod_ubpf_api.c
+++ b/prove_stuffs/mod_ubpf_api.c
@@ -16,10 +16,8 @@
 #include "mod_ubpf_api.h"
 
 #include <stdio.h>
-#include <ubpf_public.h>
 #include <stdarg.h>
 #include <string.h>
-#include "plugin_arguments.h"
 #include "../xbgp_compliant_api/xbgp_defs.h"
 #include "../xbgp_compliant_api/xbgp_plugin_api.h"
 #include <time.h>


### PR DESCRIPTION
This PR fixes the include issue of `mod_ubpf_api.c` and adds a script generating `tar.bz2` archives suitable for verification through the PDS.